### PR TITLE
Improvement Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,19 @@
 # -*- mode: ruby; coding: utf-8 -*-
 require 'rubygems'
 require 'bundler'
-
 require 'rake'
 require 'rake/clean'
 require 'rubygems/package_task'
 require 'rdoc/task'
+require 'rspec/core'
+require 'rspec/core/rake_task'
 
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.rspec_opts = ["-c","-fs"]
   spec.pattern = FileList['spec/**/*_spec.rb']
-  spec.rcov = true
 end
-
-task :spec => :check_dependencies
 
 task :default => :spec
 


### PR DESCRIPTION
Command "rake spec" seems to doesn't work.

$ rake spec
rake aborted!
Don't know how to build task 'check_dependencies'

Tasks: TOP => spec
(See full trace by running task with --trace)

I have fixed the Rakefile.
Please review.
