### PR TITLE
Rename plugins tinyurl, expand-tinyurl

### DIFF
--- a/lib/plugins/expand_url.rb
+++ b/lib/plugins/expand_url.rb
@@ -25,7 +25,7 @@ config.plugins.expand_tinyurl.set_default(:shortters, [])
 config.plugins.expand_tinyurl.set_default(:skip_users, [])
 
 Termtter::Client::register_hook(
-  :name => :expand_tinyurl,
+  :name => :expand_url,
   :point => :filter_for_output,
   :exec_proc => lambda do |statuses, event|
     shortters = URL_SHORTTERS + config.plugins.expand_tinyurl.shortters

--- a/lib/plugins/quicklook.rb
+++ b/lib/plugins/quicklook.rb
@@ -36,6 +36,6 @@ end
 
 # quicklook.rb
 # REQUIREMENTS:
-#   t.plug 'expand-tinyurl'
+#   t.plug 'expand_url'
 # TODO:
 #   Close quicklook window automatically.

--- a/lib/plugins/url_shortener.rb
+++ b/lib/plugins/url_shortener.rb
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-config.plugins.tinyurl.set_default(:shorturl_makers, [
+config.plugins.url_shortener.set_default(:shorturl_makers, [
     { :host => "api.bit.ly",
       :format => '/v3/shorten?login=termtter&apiKey=R_e7f22d523a803dbff7f67de18c109856&longUrl=%s&format=txt' },
     { :host => "is.gd", :format => '/api.php?longurl=%s' },
     { :host => "tinyurl.com", :format => '/api-create.php?url=%s' },
   ])
-config.plugins.tinyurl.set_default(:ignore_regexp, %r{
+config.plugins.url_shortener.set_default(:ignore_regexp, %r{
     \Ahttp://bit\.ly/ | \Ahttp://tinyurl\.com/ | \Ahttp://is\.gd/
   | \Ahttp://ff\.im/ | \Ahttp://j\.mp/ | \Ahttp://goo\.gl/
   | \Ahttp://tr\.im/ | \Ahttp://short\.to/ | \Ahttp://ow\.ly/
@@ -14,27 +14,27 @@ config.plugins.tinyurl.set_default(:ignore_regexp, %r{
   | \Ahttp://htn\.to/ | \Ahttp://cot\.ag/ | \Ahttp://ht\.ly/ | \Ahttp://p\.tl/
   | \Ahttp://url4\.eu/ | \Ahttp://t\.co/
 }x )
-config.plugins.tinyurl.set_default(:tinyurl_hook_commands, [:update, :reply, :retweet])
-config.plugins.tinyurl.set_default(
+config.plugins.url_shortener.set_default(:url_shortener_hook_commands, [:update, :reply, :retweet])
+config.plugins.url_shortener.set_default(
   :uri_regexp,
   /#{URI.regexp(%w(http https ftp))}\S*/ )
 
 # Shorten URLs in tweets which size is longer than this value.
 # If you want to shorten only when over termtter's limit, set `140'
-config.plugins.tinyurl.set_default(:when_over, 0)
+config.plugins.url_shortener.set_default(:when_over, 0)
 
 module Termtter::Client
   register_hook(
-    :name => :tinyurl,
-    :points => config.plugins.tinyurl.tinyurl_hook_commands.map {|cmd|
+    :name => :url_shortener,
+    :points => config.plugins.url_shortener.url_shortener_hook_commands.map {|cmd|
       "modify_arg_for_#{cmd.to_s}".to_sym
     },
     :exec_proc => lambda {|cmd, arg|
-      if config.plugins.tinyurl.when_over == 0 || # skip character count
-          arg.charsize > config.plugins.tinyurl.when_over
-        arg.gsub(config.plugins.tinyurl.uri_regexp) do |url|
+      if config.plugins.url_shortener.when_over == 0 || # skip character count
+          arg.charsize > config.plugins.url_shortener.when_over
+        arg.gsub(config.plugins.url_shortener.uri_regexp) do |url|
           result = nil
-          config.plugins.tinyurl.shorturl_makers.each do |site|
+          config.plugins.url_shortener.shorturl_makers.each do |site|
             result = shorten_url(url, site[:host], site[:format])
             break if result
           end
@@ -48,7 +48,7 @@ module Termtter::Client
 
   # returns nil if not shorten
   def self.shorten_url(url, host, format)
-    return url if config.plugins.tinyurl.ignore_regexp =~ url # already shorten
+    return url if config.plugins.url_shortener.ignore_regexp =~ url # already shorten
     url_enc = URI.escape(url, /[^a-zA-Z0-9.:]/)
     res = Termtter::HTTPpool.start(host) do |h|
       h.get(format % url_enc)
@@ -67,5 +67,5 @@ module Termtter::Client
   end
 end
 
-# tinyuri.rb
+# url_shortener.rb
 # make URLs in your update to convert tinyurl.com/XXXXXXX.

--- a/spec/plugins/expand_url_spec.rb
+++ b/spec/plugins/expand_url_spec.rb
@@ -2,14 +2,14 @@
 
 require File.expand_path(File.dirname(__FILE__)) + '/../spec_helper'
 
-describe Termtter::Client, 'when the plugin expand-tinyurl is loaded' do
+describe Termtter::Client, 'when the plugin expand_url is loaded' do
   it 'should expand url in status' do
     f = nil
     Termtter::Client.should_receive(:register_hook).once do |params|
       f = params[:exec_proc]
     end
     config.plugins.expand_tinyurl.set_default('tinyurl.com', nil)
-    Termtter::Client.plug 'expand-tinyurl'
+    Termtter::Client.plug 'expand_url'
     f.should_not be_nil
     status_struct = Struct.new(:text)
     statuses = []

--- a/spec/plugins/url_shortener_spec.rb
+++ b/spec/plugins/url_shortener_spec.rb
@@ -5,16 +5,16 @@ require 'open-uri'
 require 'uri'
 require 'net/http'
 
-describe 'plugin tinyurl' do
+describe 'plugin url_shortener' do
   before do
     Termtter::Client.setup_task_manager
   end
 
-  it 'adds hook :tinyurl' do
+  it 'adds hook :url_shortener' do
     Termtter::Client.should_receive(:register_hook).once
-    Termtter::Client.plug 'tinyurl'
-    #Termtter::Client.get_hook(:tinyurl).should be_a_kind_of(Hook)
-    #Termtter::Client.get_hook(:tinyurl).name.should == :tinyurl
+    Termtter::Client.plug 'url_shortener'
+    #Termtter::Client.get_hook(:url_shortener).should be_a_kind_of(Hook)
+    #Termtter::Client.get_hook(:url_shortener).name.should == :url_shortener
   end
 
   it 'truncates url' do
@@ -27,7 +27,7 @@ describe 'plugin tinyurl' do
         end
       end
     )
-    Termtter::Client.plug 'tinyurl'
+    Termtter::Client.plug 'url_shortener'
     Termtter::Client.execute('update http://www.google.com/')
   end
 
@@ -43,7 +43,7 @@ describe 'plugin tinyurl' do
         end
       end
     )
-    Termtter::Client.plug 'tinyurl'
+    Termtter::Client.plug 'url_shortener'
     Termtter::Client.execute('update http://ja.wikipedia.org/wiki/深田恭子')
   end
 
@@ -57,7 +57,7 @@ describe 'plugin tinyurl' do
         end
       end
     )
-    Termtter::Client.plug 'tinyurl'
+    Termtter::Client.plug 'url_shortener'
     Termtter::Client.execute('update http://ja.wikipedia.org/wiki/%E3%82%B9%E3%83%88%E3%83%AA%E3%83%BC%E3%83%88%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0')
   end
 
@@ -71,7 +71,7 @@ describe 'plugin tinyurl' do
         end
       end
     )
-    Termtter::Client.plug 'tinyurl'
+    Termtter::Client.plug 'url_shortener'
     Termtter::Client.execute('update http://www.google.co.jp/search?hl=ja&source=hp&q=ujihisa&lr=&aq=f&aqi=g4g-r6&aql=&oq=&gs_rfai=')
 
   end

--- a/termtter.gemspec
+++ b/termtter.gemspec
@@ -83,7 +83,7 @@ Gem::Specification.new do |s|
     "lib/plugins/error_log.rb",
     "lib/plugins/event_invoked_at.rb",
     "lib/plugins/exec_and_update.rb",
-    "lib/plugins/expand-tinyurl.rb",
+    "lib/plugins/expand_url.rb",
     "lib/plugins/favotter.rb",
     "lib/plugins/fib_filter.rb",
     "lib/plugins/fibyou.rb",
@@ -202,7 +202,6 @@ Gem::Specification.new do |s|
     "lib/plugins/system_status.rb",
     "lib/plugins/time_signal.rb",
     "lib/plugins/timer.rb",
-    "lib/plugins/tinyurl.rb",
     "lib/plugins/toppo.rb",
     "lib/plugins/train.rb",
     "lib/plugins/translate_tweet.rb",
@@ -214,6 +213,7 @@ Gem::Specification.new do |s|
     "lib/plugins/update_editor.rb",
     "lib/plugins/uri-open.rb",
     "lib/plugins/url.rb",
+    "lib/plugins/url_shortener.rb",
     "lib/plugins/user_stream.rb",
     "lib/plugins/w3mimg.rb",
     "lib/plugins/wassr.rb",
@@ -259,7 +259,7 @@ Gem::Specification.new do |s|
     "spec/plugins/defaults/retweet_spec.rb",
     "spec/plugins/draft_spec.rb",
     "spec/plugins/english_spec_.rb",
-    "spec/plugins/expand-tinyurl_spec.rb",
+    "spec/plugins/expand_url_spec.rb",
     "spec/plugins/fib_spec.rb",
     "spec/plugins/filter_spec_.rb",
     "spec/plugins/footer_spec.rb",
@@ -274,8 +274,8 @@ Gem::Specification.new do |s|
     "spec/plugins/standard_commands_spec.rb",
     "spec/plugins/storage/sqlite3_spec.rb",
     "spec/plugins/storage/status_spec_.rb",
-    "spec/plugins/tinyurl_spec.rb",
     "spec/plugins/truncate_spec.rb",
+    "spec/plugins/url_shortener_spec.rb",
     "spec/plugins/whois_spec_.rb",
     "spec/spec_helper.rb",
     "spec/termtter/active_rubytter_spec.rb",
@@ -302,11 +302,11 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "termtter"
-  s.rubygems_version = "1.8.23"
+  s.rubygems_version = "2.0.0"
   s.summary = "Terminal based Twitter client."
 
   if s.respond_to? :specification_version then
-    s.specification_version = 3
+    s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, ["> 1.1.3"])


### PR DESCRIPTION
[Rename]
tinyurl.rb -> url_shortener.rb
expand-tinyurl.rb -> expand_url.rb

The tinyurl.rb is not only for "tinyurl.com". (ex. bit.ly, is.gd, etc)
The expand-tinyurl is too.
